### PR TITLE
feat(multimodal): add media caching support with UUID-based lookup

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -42,6 +42,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.models import SupportsMultiModal
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalDataDict
 from vllm.multimodal.utils import MediaConnector
+from vllm.multimodal.media_cache import get_global_media_cache
 # yapf: disable
 from vllm.transformers_utils.chat_templates import (
     get_chat_template_fallback_path)
@@ -71,6 +72,9 @@ class ChatCompletionContentPartAudioParam(TypedDict, total=False):
 
     type: Required[Literal["audio_url"]]
     """The type of the content part."""
+    
+    uuid: str
+    """Optional UUID for caching this media item."""
 
 
 class ChatCompletionContentPartImageEmbedsParam(TypedDict, total=False):
@@ -82,6 +86,9 @@ class ChatCompletionContentPartImageEmbedsParam(TypedDict, total=False):
     """
     type: Required[Literal["image_embeds"]]
     """The type of the content part."""
+    
+    uuid: str
+    """Optional UUID for caching this media item."""
 
 
 class VideoURL(TypedDict, total=False):
@@ -96,6 +103,9 @@ class ChatCompletionContentPartVideoParam(TypedDict, total=False):
 
     type: Required[Literal["video_url"]]
     """The type of the content part."""
+    
+    uuid: str
+    """Optional UUID for caching this media item."""
 
 
 class PILImage(BaseModel):
@@ -127,6 +137,9 @@ class CustomChatCompletionContentSimpleImageParam(TypedDict, total=False):
     }
     """
     image_url: Required[str]
+    
+    uuid: str
+    """Optional UUID for caching this media item."""
 
 
 class CustomChatCompletionContentSimpleAudioParam(TypedDict, total=False):
@@ -138,10 +151,13 @@ class CustomChatCompletionContentSimpleAudioParam(TypedDict, total=False):
     }
     """
     audio_url: Required[str]
+    
+    uuid: str
+    """Optional UUID for caching this media item."""
 
 
 class CustomChatCompletionContentSimpleVideoParam(TypedDict, total=False):
-    """A simpler version of the param that only accepts a plain audio_url.
+    """A simpler version of the param that only accepts a plain video_url.
 
     Example:
     {
@@ -149,6 +165,20 @@ class CustomChatCompletionContentSimpleVideoParam(TypedDict, total=False):
     }
     """
     video_url: Required[str]
+    
+    uuid: str
+    """Optional UUID for caching this media item."""
+
+
+class CustomChatCompletionContentPartImageParam(TypedDict, total=False):
+    """Custom image param that extends OpenAI's with UUID support."""
+    image_url: Required[dict[str, str]]
+    
+    type: Required[Literal["image_url"]]
+    """The type of the content part."""
+    
+    uuid: str
+    """Optional UUID for caching this media item."""
 
 
 class CustomThinkCompletionContentParam(TypedDict, total=False):
@@ -181,7 +211,8 @@ ChatCompletionContentPartParam: TypeAlias = Union[
     ChatCompletionContentPartImageEmbedsParam,
     CustomChatCompletionContentSimpleAudioParam,
     CustomChatCompletionContentSimpleVideoParam, str,
-    CustomThinkCompletionContentParam]
+    CustomThinkCompletionContentParam,
+    CustomChatCompletionContentPartImageParam]
 
 
 class CustomChatCompletionMessageParam(TypedDict, total=False):
@@ -656,28 +687,29 @@ class BaseMultiModalContentParser(ABC):
         return dict(self._placeholder_storage)
 
     @abstractmethod
-    def parse_image(self, image_url: str) -> None:
+    def parse_image(self, image_url: str, uuid: Optional[str] = None) -> None:
         raise NotImplementedError
 
     @abstractmethod
     def parse_image_embeds(self,
-                           image_embeds: Union[str, dict[str, str]]) -> None:
+                           image_embeds: Union[str, dict[str, str]], 
+                           uuid: Optional[str] = None) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def parse_image_pil(self, image_pil: Image.Image) -> None:
+    def parse_image_pil(self, image_pil: Image.Image, uuid: Optional[str] = None) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def parse_audio(self, audio_url: str) -> None:
+    def parse_audio(self, audio_url: str, uuid: Optional[str] = None) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def parse_input_audio(self, input_audio: InputAudio) -> None:
+    def parse_input_audio(self, input_audio: InputAudio, uuid: Optional[str] = None) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def parse_video(self, video_url: str) -> None:
+    def parse_video(self, video_url: str, uuid: Optional[str] = None) -> None:
         raise NotImplementedError
 
 
@@ -693,14 +725,29 @@ class MultiModalContentParser(BaseMultiModalContentParser):
             allowed_local_media_path=tracker.allowed_local_media_path,
         )
 
-    def parse_image(self, image_url: str) -> None:
-        image = self._connector.fetch_image(image_url)
+    def parse_image(self, image_url: str, uuid: Optional[str] = None) -> None:
+        # Try to get from cache first
+        media_cache = get_global_media_cache()
+        
+        # Check cache with UUID or URL
+        image = media_cache.get(uuid, image_url) if (uuid or image_url) else None
+        
+        if image is None:
+            # Not in cache, fetch the image
+            if image_url:
+                image = self._connector.fetch_image(image_url)
+                # Store in cache for future use
+                media_cache.put(image, uuid, image_url)
+            else:
+                # No URL provided but UUID given - expecting cache hit
+                raise ValueError(f"Image with UUID '{uuid}' not found in cache and no URL provided")
 
         placeholder = self._tracker.add("image", image)
         self._add_placeholder("image", placeholder)
 
     def parse_image_embeds(self,
-                           image_embeds: Union[str, dict[str, str]]) -> None:
+                           image_embeds: Union[str, dict[str, str]], 
+                           uuid: Optional[str] = None) -> None:
         if isinstance(image_embeds, dict):
             embeds = {
                 k: self._connector.fetch_image_embedding(v)
@@ -714,25 +761,53 @@ class MultiModalContentParser(BaseMultiModalContentParser):
 
         self._add_placeholder("image", placeholder)
 
-    def parse_image_pil(self, image_pil: Image.Image) -> None:
+    def parse_image_pil(self, image_pil: Image.Image, uuid: Optional[str] = None) -> None:
         placeholder = self._tracker.add("image", image_pil)
         self._add_placeholder("image", placeholder)
 
-    def parse_audio(self, audio_url: str) -> None:
-        audio = self._connector.fetch_audio(audio_url)
+    def parse_audio(self, audio_url: str, uuid: Optional[str] = None) -> None:
+        # Try to get from cache first
+        media_cache = get_global_media_cache()
+        
+        # Check cache with UUID or URL
+        audio = media_cache.get(uuid, audio_url) if (uuid or audio_url) else None
+        
+        if audio is None:
+            # Not in cache, fetch the audio
+            if audio_url:
+                audio = self._connector.fetch_audio(audio_url)
+                # Store in cache for future use
+                media_cache.put(audio, uuid, audio_url)
+            else:
+                # No URL provided but UUID given - expecting cache hit
+                raise ValueError(f"Audio with UUID '{uuid}' not found in cache and no URL provided")
 
         placeholder = self._tracker.add("audio", audio)
         self._add_placeholder("audio", placeholder)
 
-    def parse_input_audio(self, input_audio: InputAudio) -> None:
+    def parse_input_audio(self, input_audio: InputAudio, uuid: Optional[str] = None) -> None:
         audio_data = input_audio.get("data", "")
         audio_format = input_audio.get("format", "")
         audio_url = f"data:audio/{audio_format};base64,{audio_data}"
 
-        return self.parse_audio(audio_url)
+        return self.parse_audio(audio_url, uuid)
 
-    def parse_video(self, video_url: str) -> None:
-        video = self._connector.fetch_video(video_url=video_url)
+    def parse_video(self, video_url: str, uuid: Optional[str] = None) -> None:
+        # Try to get from cache first
+        media_cache = get_global_media_cache()
+        
+        # Check cache with UUID or URL
+        video = media_cache.get(uuid, video_url) if (uuid or video_url) else None
+        
+        if video is None:
+            # Not in cache, fetch the video
+            if video_url:
+                video = self._connector.fetch_video(video_url=video_url)
+                # Store in cache for future use
+                media_cache.put(video, uuid, video_url)
+            else:
+                # No URL provided but UUID given - expecting cache hit
+                raise ValueError(f"Video with UUID '{uuid}' not found in cache and no URL provided")
 
         placeholder = self._tracker.add("video", video)
         self._add_placeholder("video", placeholder)
@@ -749,14 +824,37 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
             allowed_local_media_path=tracker.allowed_local_media_path
         )
 
-    def parse_image(self, image_url: str) -> None:
-        image_coro = self._connector.fetch_image_async(image_url)
-
-        placeholder = self._tracker.add("image", image_coro)
+    def parse_image(self, image_url: str, uuid: Optional[str] = None) -> None:
+        # Try to get from cache first
+        media_cache = get_global_media_cache()
+        
+        # Check cache with UUID or URL
+        cached_image = media_cache.get(uuid, image_url) if (uuid or image_url) else None
+        
+        if cached_image is not None:
+            # Create a future that returns the cached image
+            future: asyncio.Future[Image.Image] = asyncio.Future()
+            future.set_result(cached_image)
+            placeholder = self._tracker.add("image", future)
+        else:
+            # Not in cache, fetch the image
+            if image_url:
+                async def fetch_and_cache():
+                    image = await self._connector.fetch_image_async(image_url)
+                    media_cache.put(image, uuid, image_url)
+                    return image
+                    
+                image_coro = fetch_and_cache()
+                placeholder = self._tracker.add("image", image_coro)
+            else:
+                # No URL provided but UUID given - expecting cache hit
+                raise ValueError(f"Image with UUID '{uuid}' not found in cache and no URL provided")
+        
         self._add_placeholder("image", placeholder)
 
     def parse_image_embeds(self,
-                           image_embeds: Union[str, dict[str, str]]) -> None:
+                           image_embeds: Union[str, dict[str, str]], 
+                           uuid: Optional[str] = None) -> None:
         future: asyncio.Future[Union[str, dict[str, str]]] = asyncio.Future()
 
         if isinstance(image_embeds, dict):
@@ -774,30 +872,74 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         placeholder = self._tracker.add("image_embeds", future)
         self._add_placeholder("image", placeholder)
 
-    def parse_image_pil(self, image_pil: Image.Image) -> None:
+    def parse_image_pil(self, image_pil: Image.Image, uuid: Optional[str] = None) -> None:
         future: asyncio.Future[Image.Image] = asyncio.Future()
         future.set_result(image_pil)
 
         placeholder = self._tracker.add("image", future)
         self._add_placeholder("image", placeholder)
 
-    def parse_audio(self, audio_url: str) -> None:
-        audio_coro = self._connector.fetch_audio_async(audio_url)
-
-        placeholder = self._tracker.add("audio", audio_coro)
+    def parse_audio(self, audio_url: str, uuid: Optional[str] = None) -> None:
+        # Try to get from cache first
+        media_cache = get_global_media_cache()
+        
+        # Check cache with UUID or URL
+        cached_audio = media_cache.get(uuid, audio_url) if (uuid or audio_url) else None
+        
+        if cached_audio is not None:
+            # Create a future that returns the cached audio
+            future: asyncio.Future = asyncio.Future()
+            future.set_result(cached_audio)
+            placeholder = self._tracker.add("audio", future)
+        else:
+            # Not in cache, fetch the audio
+            if audio_url:
+                async def fetch_and_cache():
+                    audio = await self._connector.fetch_audio_async(audio_url)
+                    media_cache.put(audio, uuid, audio_url)
+                    return audio
+                    
+                audio_coro = fetch_and_cache()
+                placeholder = self._tracker.add("audio", audio_coro)
+            else:
+                # No URL provided but UUID given - expecting cache hit
+                raise ValueError(f"Audio with UUID '{uuid}' not found in cache and no URL provided")
+        
         self._add_placeholder("audio", placeholder)
 
-    def parse_input_audio(self, input_audio: InputAudio) -> None:
+    def parse_input_audio(self, input_audio: InputAudio, uuid: Optional[str] = None) -> None:
         audio_data = input_audio.get("data", "")
         audio_format = input_audio.get("format", "")
         audio_url = f"data:audio/{audio_format};base64,{audio_data}"
 
-        return self.parse_audio(audio_url)
+        return self.parse_audio(audio_url, uuid)
 
-    def parse_video(self, video_url: str) -> None:
-        video = self._connector.fetch_video_async(video_url=video_url)
-
-        placeholder = self._tracker.add("video", video)
+    def parse_video(self, video_url: str, uuid: Optional[str] = None) -> None:
+        # Try to get from cache first
+        media_cache = get_global_media_cache()
+        
+        # Check cache with UUID or URL
+        cached_video = media_cache.get(uuid, video_url) if (uuid or video_url) else None
+        
+        if cached_video is not None:
+            # Create a future that returns the cached video
+            future: asyncio.Future = asyncio.Future()
+            future.set_result(cached_video)
+            placeholder = self._tracker.add("video", future)
+        else:
+            # Not in cache, fetch the video
+            if video_url:
+                async def fetch_and_cache():
+                    video = await self._connector.fetch_video_async(video_url=video_url)
+                    media_cache.put(video, uuid, video_url)
+                    return video
+                    
+                video_coro = fetch_and_cache()
+                placeholder = self._tracker.add("video", video_coro)
+            else:
+                # No URL provided but UUID given - expecting cache hit
+                raise ValueError(f"Video with UUID '{uuid}' not found in cache and no URL provided")
+        
         self._add_placeholder("video", placeholder)
 
 
@@ -1092,6 +1234,8 @@ def _parse_chat_message_content_part(
         return part
     # Handle structured dictionary parts
     part_type, content = _parse_chat_message_content_mm_part(part)
+    # Extract UUID if present
+    uuid = part.get("uuid") if isinstance(part, dict) else None
     # if part_type is text/refusal/image_url/audio_url/video_url/input_audio but
     # content is None, log a warning and skip
     if part_type in VALID_MESSAGE_CONTENT_MM_PART_TYPES and content is None:
@@ -1110,27 +1254,27 @@ def _parse_chat_message_content_part(
     modality = None
     if part_type == "image_pil":
         image_content = cast(Image.Image, content)
-        mm_parser.parse_image_pil(image_content)
+        mm_parser.parse_image_pil(image_content, uuid)
         modality = "image"
     elif part_type in ("image_url", "input_image"):
-        str_content = cast(str, content)
-        mm_parser.parse_image(str_content)
+        str_content = cast(str, content) if content else ""
+        mm_parser.parse_image(str_content, uuid)
         modality = "image"
     elif part_type == "image_embeds":
         content = cast(Union[str, dict[str, str]], content)
-        mm_parser.parse_image_embeds(content)
+        mm_parser.parse_image_embeds(content, uuid)
         modality = "image"
     elif part_type == "audio_url":
-        str_content = cast(str, content)
-        mm_parser.parse_audio(str_content)
+        str_content = cast(str, content) if content else ""
+        mm_parser.parse_audio(str_content, uuid)
         modality = "audio"
     elif part_type == "input_audio":
         dict_content = cast(InputAudio, content)
-        mm_parser.parse_input_audio(dict_content)
+        mm_parser.parse_input_audio(dict_content, uuid)
         modality = "audio"
     elif part_type == "video_url":
-        str_content = cast(str, content)
-        mm_parser.parse_video(str_content)
+        str_content = cast(str, content) if content else ""
+        mm_parser.parse_video(str_content, uuid)
         modality = "video"
     else:
         raise NotImplementedError(f"Unknown part type: {part_type}")

--- a/vllm/multimodal/media_cache.py
+++ b/vllm/multimodal/media_cache.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Optional, Union
+import hashlib
+from vllm.utils import LRUCache, GiB_bytes
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+MediaData = Union[object, str, bytes]  # Can be image, audio, video, embeddings, etc.
+
+class MediaCache:
+    """
+    Global cache for media data, using UUID or content hash as key.
+    This allows reusing media data across multiple requests.
+    """
+    
+    def __init__(self, capacity_gb: float = 1.0) -> None:
+        self._cache = LRUCache[str, MediaData](
+            capacity=int(GiB_bytes * capacity_gb)
+        )
+    
+    def _get_url_hash(self, url: str) -> str:
+        """Generate a hash for a URL to use as cache key."""
+        return hashlib.sha256(url.encode()).hexdigest()
+    
+    def get(self, uuid: Optional[str], url: Optional[str] = None) -> Optional[MediaData]:
+        """
+        Get media data from cache.
+        
+        Args:
+            uuid: User-provided UUID for the media
+            url: URL of the media (used as fallback key if UUID not provided)
+        
+        Returns:
+            Cached media data if found, None otherwise
+        """
+        if uuid:
+            cache_key = uuid
+        elif url:
+            cache_key = self._get_url_hash(url)
+        else:
+            return None
+            
+        return self._cache.get(cache_key)
+    
+    def put(self, data: MediaData, uuid: Optional[str] = None, url: Optional[str] = None) -> str:
+        """
+        Store media data in cache.
+        
+        Args:
+            data: The media data to cache
+            uuid: User-provided UUID for the media
+            url: URL of the media (used to generate key if UUID not provided)
+            
+        Returns:
+            The cache key used
+        """
+        if uuid:
+            cache_key = uuid
+        elif url:
+            cache_key = self._get_url_hash(url)
+        else:
+            raise ValueError("Either uuid or url must be provided")
+            
+        self._cache[cache_key] = data
+        return cache_key
+    
+    def clear(self) -> None:
+        """Clear all cached media data."""
+        self._cache.clear()
+
+
+# Global instance
+_global_media_cache = MediaCache()
+
+def get_global_media_cache() -> MediaCache:
+    """Get the global media cache instance."""
+    return _global_media_cache


### PR DESCRIPTION
- Introduce global media cache for images, audio, and video
- Add UUID field to multimodal content part parameters
- Modify parsers to accept optional UUIDs for caching
- Implement synchronous and asynchronous cache-aware fetching
- Create MediaCache class with LRU eviction policy
- Support content deduplication via UUID or URL hashing

Original Ticket:
Motivation.

The current processing flow of media inputs (image/video/audio/embeddings) has several inefficiencies when media is used repeatedly (e.g. multi-turn or when the same media is used in different requests). The current processing flow looks like this when a media is provided in the input:

    MediaConnector runs to download the input (if a remote URL is provided), incurring network delays
    MediaConnector loads the downloaded bytes into python objects (e.g. PIL.Image, audio/video decoding), incurring CPU delays
    BaseMultiModalProcessor then hashes the entire media using its full bytes to do cache lookup from ProcessingCache, incurring CPU delays

All three are run before any cache is checked, therefore repeated media still incur these costs even if there’s a cache hit later on. Additionally, decoding long video & hashing based on all bytes can be slow (millisecs to tens of millisecs) and inefficient. For media that are sent repeatedly, we want to bypass all three steps. Proposed Change.
Proposal

    Add a user provided “uuid” field in media inputs as the media’s identifier & hash key
    Example:

{"type": "image_url", "image_url": {"url": image_url}, "uuid": “abcde”}
{"type": "image_embeds", "image_embeds": “xyz”, "uuid": “abcde”}}

    For URL inputs without a uuid set, hash only the URL instead of the entire bytes. For other inputs, we fall back to full hashing of bytes. We should then allow empty media inputs if uuids are provided (i.e. if the client expects a cache hit).
    During input processing, first check ProcessingCache to see if any media is already cached, and bypass MediaConnector altogether on cache hit.

Potential Issues

Compatibility with OAI API
OAI API currently doesn’t support user-provided uuids, so adding this field would introduce more discrepancy between the APIs. However, given that this is an additional field, the impact should be minimal.

Race Condition Between Cache Lookup Cache Read
(Needs confirmation). Given that the cache is checked when parsing contents but the lookup is performed later, we could potentially have a cache miss after the initial check (i.e. eviction between lookup & cache read). We could just fail the one single request if that happens.

# Essential Elements of an Effective PR Description Checklist

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.


## Purpose

## Test Plan

## Test Result

## (Optional) Documentation Update

